### PR TITLE
Changing pip install instructions for pyspedas.

### DIFF
--- a/pyspedas_examples/notebooks/mth5/THEMIS-ARTEMIS-Post-AGU2023_load_fdsn_example.ipynb
+++ b/pyspedas_examples/notebooks/mth5/THEMIS-ARTEMIS-Post-AGU2023_load_fdsn_example.ipynb
@@ -6,12 +6,13 @@
    "source": [
     "# https://colab.research.google.com/github/spedas/pyspedas_examples/blob/master/pyspedas_examples/notebooks/mth5/THEMIS-ARTEMIS-Post-AGU2023_load_fdsn_example.ipynb\n",
     "# Uncomment the \"!pip install\" lines below to use on Google Colab. Run this cell and restart the runtime kernel.\n",
-    "# !pip install git+https://github.com/spedas/pyspedas.git\n",
+    "# !pip install pyspedas\n",
     "# !pip install mth5\n",
     "\n",
     "# If you encounter installation problem try to install the packages from the git repositories\n",
     "# !pip install git+https://github.com/kujaku11/mt_metadata.git\n",
-    "# !pip install git+https://github.com/kujaku11/mth5.git"
+    "# !pip install git+https://github.com/kujaku11/mth5.git\n",
+    "# !pip install git+https://github.com/spedas/pyspedas.git"
    ],
    "metadata": {
     "collapsed": false,

--- a/pyspedas_examples/notebooks/mth5/comparison_with_published_results.ipynb
+++ b/pyspedas_examples/notebooks/mth5/comparison_with_published_results.ipynb
@@ -15,12 +15,13 @@
    "source": [
     "# Uncomment the \"!pip install\" line below to use on Google Colab. Run this cell and restart the runtime kernel.\n",
     "# https://colab.research.google.com/github/spedas/pyspedas_examples/blob/master/pyspedas_examples/notebooks/mth5/comparison_with_published_results.ipynb\n",
-    "# !pip install git+https://github.com/spedas/pyspedas.git\n",
+    "# !pip install pyspedas\n",
     "# !pip install mth5\n",
     "\n",
     "# If you encounter installation problem try to install the packages from the git repositories\n",
     "# !pip install git+https://github.com/kujaku11/mt_metadata.git\n",
-    "# !pip install git+https://github.com/kujaku11/mth5.git"
+    "# !pip install git+https://github.com/kujaku11/mth5.git\n",
+    "# !pip install git+https://github.com/spedas/pyspedas.git"
    ],
    "metadata": {
     "collapsed": false,


### PR DESCRIPTION
The instructions are updated with `!pip install pyspedas` as it now supports mth5 from the package.
Would be useful to have this mere done before GEM. I tested it via Google Colab.
